### PR TITLE
fix: render links as HTML links

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -46,9 +46,11 @@ const MenuBar = ({ items }: { items: MenuItem[] }) => (
   <Flex as="nav" direction={["column", "row", null]} align="center">
     {items.map(({ title, to }) => (
       <Link href={to} key={title}>
-        <Box key={title} m="2">
-          <Text fontFamily="Raleway">{title}</Text>
-        </Box>
+        <a>
+          <Box key={title} m="2">
+            <Text fontFamily="Raleway">{title}</Text>
+          </Box>
+        </a>
       </Link>
     ))}
   </Flex>
@@ -79,7 +81,9 @@ export const Header = () => {
       <Container maxW="container.xl" my="2">
         <Flex align="center" justify="space-between">
           <Link href="/">
-            <Logo />
+            <a>
+              <Logo />
+            </a>
           </Link>
           <Box display={["none", "block"]}>
             <MenuBar items={menuItems} />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,8 +50,8 @@ export const Index: NextPage = () => {
                 the software.
               </Text>
               <ButtonGroup>
-                <Link href="/about">
-                  <Button colorScheme="blue">Learn More</Button>
+                <Link href="/about" passHref>
+                  <Button as="a" colorScheme="blue">Learn More</Button>
                 </Link>
 
                 <Button


### PR DESCRIPTION
so they can be copied, opened in new tabs, focused, previewed, and all the other important default behaviours that the semantic link element has.